### PR TITLE
Fix name of open file constant.

### DIFF
--- a/gen_uuid.c
+++ b/gen_uuid.c
@@ -461,7 +461,7 @@ static void close_all_fds(void)
 	getrlimit(RLIMIT_NOFILE, &rl);
 	max = rl.rlim_cur;
 #else
-	max = OPEN_MAX;
+	max = FOPEN_MAX;
 #endif
 
 	for (i=0; i < max; i++) {


### PR DESCRIPTION
According to [this](https://stackoverflow.com/questions/14042824/where-is-open-max-defined-for-linux-systems) post the constant should be `FOPEN_MAX`.